### PR TITLE
Include subdirectories and non-python packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include LICENSE
+include README.md
+recursive-include contentious/templates *
+recursive-include contentious/static *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
+from setuptools import find_packages
+
+PACKAGES = find_packages()
 
 setup(name='Contentious',
       version='1.0',
@@ -8,5 +11,5 @@ setup(name='Contentious',
       author='Adam Alton - Potato London Ltd',
       author_email='adam@potatolondon.com',
       url='https://github.com/potatolondon/contentious',
-      packages=['contentious'],
+      packages=PACKAGES,
      )

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,5 @@ setup(name='Contentious',
       author_email='adam@potatolondon.com',
       url='https://github.com/potatolondon/contentious',
       packages=PACKAGES,
+      include_package_data=True,
      )


### PR DESCRIPTION
When using pip to install contentious it would only install the top level .py files, changed the setup.py to install all python packages, and also included a MANIFEST.in to include the contentious/static and contentious/templates files.