### PR TITLE
Allow customization of TREAT_CONTENT_AS_HTML_TAGS and SELF_CLOSING_HTML_...

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,25 @@ MyContentious.prototype.closeDialog = function(){
 var cts = new MyContentious();
 ```
 
+## Dealing with HTML content
+You can define the content of specific tags to be treated as HTML. 
+This means Contentious will **not** escape the content before rendering. Also the editor dialogue will display it verbatim inside a textarea (useful if you wish to add the WYSIWYG of your choice for example). You may customize which tags are treated this way by populating the `treatContentAsHTML` option when instantiating the Contentious javascript class.
+
+```
+function MyContentious(){}
+MyContentious.prototype = new Contentious({
+    ...
+    'treatContentAsHTML': ['div', 'p']
+})
+
+var ctx = new MyContentious();
+```
+
+You **must** also mirror this on the Python side by setting the `CONTENTIOUS_TREAT_CONTENT_AS_HTML_TAGS` option in your Django settings file.
+
+```
+...
+CONTENTIOUS_TREAT_CONTENT_AS_HTML_TAGS = ('div', 'p')
+...
+```
+

--- a/contentious/constants.py
+++ b/contentious/constants.py
@@ -1,4 +1,10 @@
-SELF_CLOSING_HTML_TAGS = ['img', 'br', 'hr', 'meta']
+from django.conf import settings
+
+
+SELF_CLOSING_HTML_TAGS = getattr(settings,
+    'CONTENTIOUS_SELF_CLOSING_HTML_TAGS', ['img', 'br', 'hr', 'meta'])
+
 
 #Note, the Javascript plugin has its own seprate copy of this:
-TREAT_CONTENT_AS_HTML_TAGS = ['div', 'select', 'ul']
+TREAT_CONTENT_AS_HTML_TAGS = getattr(settings,
+    'CONTENTIOUS_TREAT_CONTENT_AS_HTML_TAGS', ['div', 'select', 'ul'])

--- a/contentious/constants.py
+++ b/contentious/constants.py
@@ -1,8 +1,7 @@
 from django.conf import settings
 
 
-SELF_CLOSING_HTML_TAGS = getattr(settings,
-    'CONTENTIOUS_SELF_CLOSING_HTML_TAGS', ['img', 'br', 'hr', 'meta'])
+SELF_CLOSING_HTML_TAGS = ['img', 'br', 'hr', 'meta']
 
 
 #Note, the Javascript plugin has its own seprate copy of this:


### PR DESCRIPTION
Currently TREAT_CONTENT_AS_HTML_TAGS is hardcoded in `constants.py`. This is configurable on the js side so should be possible on the Python side. Adding SELF_CLOSING_HTML_TAGS also for completeness.