### PR TITLE
Use offset() instead of position() to determine element position.

### DIFF
--- a/contentious/static/contentious/js/contentious.js
+++ b/contentious/static/contentious/js/contentious.js
@@ -406,7 +406,7 @@ var Contentious = (function(){
 	klass.prototype.centralise = function(element, container){
 		var $container = $(container),
 			$element = $(element),
-			containerOffset = $container.position();
+			containerOffset = $container.offset();
 		$element.css('top', containerOffset.top + ($container.outerHeight(true)/2 - $element.height()/2));
 		$element.css('left', containerOffset.left + ($container.outerWidth(true)/2 - $element.width()/2));
 	};


### PR DESCRIPTION
When using contentious with elements positioned relatively, .position() causes the edit buttons to be positioned using their relative top and left (so they end up at the top of the page). Changing to offset relative to the whole page positions the button correctly.