### PR TITLE
Adapts Contentious to be Django 1.8 compatible.

### DIFF
--- a/contentious/compat.py
+++ b/contentious/compat.py
@@ -1,0 +1,13 @@
+from django.template import RequestContext
+
+# Django 1.8 does not render context processors when you create the object
+# RequestContext, but instead when you are rendering it into a template.
+
+# If 'request' is not in the created context, we manually add it.
+def get_request_context(request):
+    context = RequestContext(request)
+
+    if 'request' not in context:
+        context.update({'request': request})
+
+    return context

--- a/contentious/contrib/basicedit/tests.py
+++ b/contentious/contrib/basicedit/tests.py
@@ -1,11 +1,11 @@
 #LIBRARIES
 from django.core.cache import cache
 from django.http import HttpRequest
-from django.template import RequestContext
 from django.test import TestCase
 from django.test.utils import override_settings
 
 #CONTENTIOUS
+from contentious.compat import get_request_context
 from .api import BasicEditAPI
 
 
@@ -20,7 +20,7 @@ class APITest(TestCase):
         api = BasicEditAPI()
         request = HttpRequest()
         request.path = '/test_view/'
-        context = RequestContext(request)
+        context = get_request_context(request)
         #First test that trying to get content for something that hasn't been saved returns {}
         result = api.get_content_data('some_key', context)
         self.assertEqual(result, {})
@@ -35,7 +35,7 @@ class APITest(TestCase):
         cache.clear()
         request = HttpRequest()
         request.path = '/test_view/'
-        context = RequestContext(request)
+        context = get_request_context(request)
         result = api.get_content_data('some_key', context)
         self.assertIsSubDict(data, result)
 

--- a/contentious/contrib/basictrans/tests.py
+++ b/contentious/contrib/basictrans/tests.py
@@ -3,10 +3,10 @@
 #LIBRARIES
 from django.core.cache import cache
 from django.http import HttpRequest
-from django.template import RequestContext
 from django.test import TestCase
 
 #CONTENTIOUS
+from contentious.compat import get_request_context
 from .api import BasicTranslationAPI
 
 
@@ -21,12 +21,12 @@ class APITest(TestCase):
         request_en = HttpRequest()
         request_en.path = '/test_view/'
         request_en.language = "en-UK"
-        context_en = RequestContext(request_en)
+        context_en = get_request_context(request_en)
         # Create an request with the language set to Spanish
         request_es = HttpRequest()
         request_es.path = '/test_view/'
         request_es.language = "es-ES"
-        context_es = RequestContext(request_es)
+        context_es = get_request_context(request_es)
 
         #First test that trying to get content for something that hasn't been saved returns {}
         result_en = api.get_content_data('some_key', context_en)
@@ -51,12 +51,12 @@ class APITest(TestCase):
         request_en = HttpRequest()
         request_en.path = '/test_view/'
         request_en.language = "en-UK"
-        context_en = RequestContext(request_en)
+        context_en = get_request_context(request_en)
 
         request_es = HttpRequest()
         request_es.path = '/test_view/'
         request_es.language = "es-ES"
-        context_es = RequestContext(request_es)
+        context_es = get_request_context(request_es)
 
         result_en = api.get_content_data('some_key', context_en)
         result_es = api.get_content_data('some_key', context_es)

--- a/contentious/decorators.py
+++ b/contentious/decorators.py
@@ -1,15 +1,15 @@
 #LIBRARIES
 from django.http import HttpResponseForbidden
-from django.template import RequestContext
 
 #CONTENTIOUS
 from contentious.api import api
+from contentious.compat import get_request_context
 
 
 def require_edit_mode(function):
     """ View function decorator for requiring api.in_edit_mode to be True. """
     def replacement(request, *args, **kwargs):
-        context = RequestContext(request)
+        context = get_request_context(request)
         if not api.in_edit_mode(context):
             return HttpResponseForbidden()
         return function(request, *args, **kwargs)

--- a/contentious/views.py
+++ b/contentious/views.py
@@ -1,11 +1,11 @@
 #LIBRARIES
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse
-from django.template import RequestContext
 from django.views.decorators.http import require_POST
 
 #CONTENTIOUS
 from contentious.api import api
+from contentious.compat import get_request_context
 from contentious.decorators import require_edit_mode
 from contentious.utils import json_response_from_exception
 
@@ -20,7 +20,7 @@ def save_content(request):
     key = data.pop('key')
     data.pop('csrfmiddlewaretoken', None)
     try:
-        api.save_content_data(key, data, RequestContext(request))
+        api.save_content_data(key, data, get_request_context(request))
         return HttpResponse('ok')
     except ValidationError as e:
         return json_response_from_exception(e)


### PR DESCRIPTION
For some reason, now Django renders the context_processors when
you render the template, not when you create the RequestContext
object. Meaning that some times we won't have the request object.