### PR TITLE
Fixed RemovedInDjango19Warning

### DIFF
--- a/contentious/api.py
+++ b/contentious/api.py
@@ -1,6 +1,7 @@
+from importlib import import_module
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
 
 
 class ContentiousInterface(object):


### PR DESCRIPTION
* Assuming we only support Python 2.7+, which was the release where importlib was added to the standard library.